### PR TITLE
Fixes: The each() function is deprecated

### DIFF
--- a/demos/Zend/Mobile/Push/ApnsFeedback.php
+++ b/demos/Zend/Mobile/Push/ApnsFeedback.php
@@ -15,7 +15,7 @@ try {
 }
  
 $tokens = $apns->feedback();
-while(list($token, $time) = each($tokens)) {
+foreach ($tokens as $token => $time) {
     echo $time . "\t" . $token . PHP_EOL;
 }
 $apns->close();

--- a/library/Zend/Cache/Backend.php
+++ b/library/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }

--- a/library/Zend/Config/Yaml.php
+++ b/library/Zend/Config/Yaml.php
@@ -289,7 +289,7 @@ class Zend_Config_Yaml extends Zend_Config
     {
         $config   = array();
         $inIndent = false;
-        while (list($n, $line) = each($lines)) {
+        foreach ($lines as $n => $line) {
             $lineno = $n + 1;
 
             $line = rtrim(preg_replace("/#.*$/", "", $line));

--- a/library/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
+++ b/library/Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php
@@ -88,7 +88,7 @@ class Zend_Http_UserAgent_Features_Adapter_TeraWurfl implements Zend_Http_UserAg
             if (!is_array($group)) {
                 continue;
             }
-            while (list ($key, $value) = each($group)) {
+            foreach ($group as $key => $value) {
                 if (is_bool($value)) {
                     // to have the same type than the official WURFL API
                     $features[$key] = ($value ? 'true' : 'false');

--- a/tests/Zend/XmlRpc/RequestTest.php
+++ b/tests/Zend/XmlRpc/RequestTest.php
@@ -288,14 +288,14 @@ class Zend_XmlRpc_RequestTest extends PHPUnit_Framework_TestCase
 
         $result = $sx->xpath('//methodName');
         $count = 0;
-        while (list( , $node) = each($result)) {
+        foreach ($result as $node) {
             ++$count;
         }
         $this->assertEquals(1, $count, $xml);
 
         $result = $sx->xpath('//params');
         $count = 0;
-        while (list( , $node) = each($result)) {
+        foreach ($result as $node) {
             ++$count;
         }
         $this->assertEquals(1, $count, $xml);


### PR DESCRIPTION
The each() function is deprecated. This message will be suppressed on further calls in /library/Zend/Cache/Backend.php on line 79
