### PR TITLE
SSL Offloading

### DIFF
--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -961,7 +961,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      */
     public function isSecure()
     {
-        return ($this->getScheme() === self::SCHEME_HTTPS);
+        return ($this->getScheme() === self::SCHEME_HTTPS) || ($this->getHeader('X_FORWARDED_PROTO') === 'https');
     }
 
     /**


### PR DESCRIPTION
A request is considered secure and thus links should be generated with https even when behind a reverse proxy.